### PR TITLE
Fix findChild occurences for minified code

### DIFF
--- a/src/map.tsx
+++ b/src/map.tsx
@@ -6,6 +6,8 @@ import olView from "ol/view"
 import * as React from "react"
 import "./map.css"
 import { Util } from "./util"
+import {Controls} from "./controls";
+import {Interactions} from "./interactions";
 
 export const MapContext = React.createContext({});
 
@@ -88,8 +90,8 @@ export class Map extends React.Component<any, any> {
 
         console.log("Loaded view:", options);
 
-        let controlsCmp = Util.findChild(this.props.children, "Controls") || {};
-        let interactionsCmp = Util.findChild(this.props.children, "Interactions") || {};
+        let controlsCmp = Util.findChild(this.props.children, Controls) || {};
+        let interactionsCmp = Util.findChild(this.props.children, Interactions) || {};
 
         options.controls = olControl.defaults(controlsCmp.props).extend(this.controls);
         options.interactions = olInteraction.defaults(interactionsCmp.props).extend(this.interactions);

--- a/src/util.tsx
+++ b/src/util.tsx
@@ -64,12 +64,12 @@ function cloneObject(obj) {
     return obj
 }
 
-function findChild(children: any, childType: string) {
+function findChild(children: any, childType: any) {
     let found: any
     let childrenArr = React.Children.toArray(children)
     for (let i = 0; i < childrenArr.length; i++) {
         let child: any = childrenArr[i]
-        if (child.type.name == childType) {
+        if (child.type == childType) {
             found = child
             break
         }


### PR DESCRIPTION
The name of stateless components is equal to the function name, which might get lost during minification. This changes the code to compare the types by value rather than their name.

You're probably not maintaining this fork anymore but I thought it was worthwhile to at least put my changes out there.